### PR TITLE
Updated gulp sassdoc task

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -133,7 +133,7 @@ gulp.task("watch", "Watches your SASS files", function() {
 gulp.task("sassdoc", "Create the Scss documentation for your project", function() {
   return gulp.src(config.path.scss + "/utils/**/*.scss")
     .pipe(sassdoc({
-      dest: "sassdoc"
+      dest: "dist/sassdoc"
     }));
 });
 

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -131,7 +131,7 @@ gulp.task("watch", "Watches your SASS files", function() {
 // -----------------------------------------------------------------------------
 
 gulp.task("sassdoc", "Create the Scss documentation for your project", function() {
-  return gulp.src("assets/scss/utils/**/*.scss")
+  return gulp.src(config.path.scss + "/utils/**/*.scss")
     .pipe(sassdoc({
       dest: "sassdoc"
     }));


### PR DESCRIPTION
Updated src path of gulp sassdoc task and changed the destination to /dist/sassdoc. This way you can access the sassdoc by adding /sassdoc/index.html to the localhost.
