### PR TITLE
Issue 35: added modular scale variables to utils folder

### DIFF
--- a/src/scss/utils/variables/_bourbon.scss
+++ b/src/scss/utils/variables/_bourbon.scss
@@ -1,0 +1,11 @@
+/// Override the modular-scale-ratio variable with a bourbon variable or a custom value.
+/// $perfect-fourth is the bourbon default.
+//// @group Typography
+//// @type Variable/value
+$modular-scale-ratio: $perfect-fourth;
+
+/// Override the modular-scale-base variable with a custom value.
+/// The default here is em($em-base), where the default value for $em-base is 16px.
+//// @group Typography
+//// @type Variable/value
+$modular-scale-base: em($em-base);

--- a/src/scss/utils/variables/_typography.scss
+++ b/src/scss/utils/variables/_typography.scss
@@ -24,16 +24,3 @@ $rhythm-unit: "rem";
 $rem-with-px-fallback: false;
 
 $round-to-nearest-half-line: true;
-
-/// Uncomment to override the modular-scale-ratio variable with a bourbon variable or a custom value.
-/// $perfect-fourth is the bourbon default.
-//// @group Typography
-//// @type Variable/value
-// $modular-scale-ratio: $perfect-fourth;
-
-/// Uncomment to override the modular-scale-base variable with a custom value.
-/// The default here is em($em-base), where the default value for $em-base is 16px.
-//// @group Typography
-//// @type Variable/value
-// $modular-scale-base: em($em-base);
-

--- a/src/scss/utils/variables/_typography.scss
+++ b/src/scss/utils/variables/_typography.scss
@@ -24,3 +24,16 @@ $rhythm-unit: "rem";
 $rem-with-px-fallback: false;
 
 $round-to-nearest-half-line: true;
+
+/// Uncomment to override the modular-scale-ratio variable with a bourbon variable or a custom value.
+/// $perfect-fourth is the bourbon default.
+//// @group Typography
+//// @type Variable/value
+// $modular-scale-ratio: $perfect-fourth;
+
+/// Uncomment to override the modular-scale-base variable with a custom value.
+/// The default here is em($em-base), where the default value for $em-base is 16px.
+//// @group Typography
+//// @type Variable/value
+// $modular-scale-base: em($em-base);
+


### PR DESCRIPTION
Removed modular scale variables from typography variables and moved them to a new _bourbon.scss file with bourbon variables. These bourbon defaults can be overriden here if needed.
Closes #35 
