### PR TITLE
issue #34: refactor the font-face include

### DIFF
--- a/src/scss/base/_typography.scss
+++ b/src/scss/base/_typography.scss
@@ -3,4 +3,4 @@
 // This file contains all typography styling: body, h1..6, p, li, a, blockquote, etc.
 // ====================================================================================================== //
 
-// @include font-face("NAME", font-files("FILE.woff", "FILE.ttf", "FILE.otf", "FILE.svg"), "FILE.eot")
+// @include font-face("NAME", "../font/NAME/FONTNAME", $file-formats: eot ttf woff);


### PR DESCRIPTION
Removed the compass syntax for the font-face include and replaced it with a bourbon syntax example.
Closes #34 
