### PR TITLE
#22: Refactor on font mixins and added size parrameter

### DIFF
--- a/src/scss/utils/mixins/_icons.scss
+++ b/src/scss/utils/mixins/_icons.scss
@@ -1,30 +1,39 @@
 /// Include a Font Awesome icon
 //// @group Icons
 /// @param {string} $code [none] - code icon ("\000")
-@mixin fontawesome-icon ($code) {
-  @include fontsmoothing();
-  color: inherit;
-  content: $code;
-  line-height: inherit;
-  speak: none;
-  display: inline-block;
-  font: normal normal normal 14px/1 FontAwesome;
-  font-size: inherit;
-  text-rendering: auto;
-  transform: translate(0, 0);
+/// @param {number} $size [16] - font size to scale the icon, px unit or unitless
+@mixin fontawesome-icon ($code, $size: 16) {
+  @Include icon($code, FontAwesome, $size);
 }
 
 /// Include a Fontello icon
 //// @group Icons
 /// @param {string} $code [none] - code icon ("\000")
-@mixin fontello-icon ($code) {
+/// @param {number} $size [16] - font size to scale the icon, px unit or unitless
+@mixin fontello-icon ($code, $size: 16) {
+  @Include icon($code, Fontello, $size);
+}
+
+/// Include a Icon
+//// @group Icons
+/// @param {string} $code [none] - code icon ("\000")
+/// @param {string} $font [FontAwesome] - font name of the iconset
+/// @param {number} $size [16] - font size to scale the icon, px unit or unitless
+@mixin icon ($code, $font: FontAwesome, $size: 16) {
+  @if (unitless($size)) {
+    $size: #{$size}px;
+  }
+
   @include fontsmoothing();
   color: inherit;
   content: $code;
-  line-height: 1;
+
+  line-height: 1 !important;
+  font-size: $size;
   speak: none;
   display: inline-block;
-  font-family: Fontello;
+
+  font-family: FontAwesome;
   text-rendering: auto;
   transform: translate(0, 0);
 }


### PR DESCRIPTION
This closes #22 
I added a parrameter for the fontawesome-icon and fontello-icon mixins and I created a general icon mixin that accepts a code font and size. Imagine there will be a third icon client or just to use a shortcut to font awesome. This is the default font of the icon mixin.

Demo:

``` scss
@include icon ("\bla"); // spits out font awesome icon 16px large;
@include icon ("\bla", Fontello, 32px); // spits out Fontello icon 32px large
// same as
@include fontawesome-icon ("\bla"); // spits out font awesome icon 16px large;
@include fontello-icon ("\bla", 32px); // spits out Fontello icon 32px large
```
